### PR TITLE
Add tests for recursive types in defaulter-gen

### DIFF
--- a/examples/defaulter-gen/output_tests/wholepkg/a.go
+++ b/examples/defaulter-gen/output_tests/wholepkg/a.go
@@ -38,3 +38,19 @@ type Struct_No_Field_Has_Manual_Defaulter struct {
 	TypeMeta   struct{}
 	OtherField string
 }
+
+// Recursive_Struct_A_With_Manual_Defaulter has recursive types structA and structB
+type Recursive_Struct_A_With_Manual_Defaulter struct {
+	TypeMeta      struct{}
+	ManualDefault ManualDefault
+	OtherField    string
+	structA       *Recursive_Struct_A_With_Manual_Defaulter
+	structB       Recursive_Struct_B_With_Manual_Defaulter
+}
+
+type Recursive_Struct_B_With_Manual_Defaulter struct {
+	TypeMeta      struct{}
+	ManualDefault ManualDefault
+	OtherField    string
+	structA       *Recursive_Struct_A_With_Manual_Defaulter
+}

--- a/examples/defaulter-gen/output_tests/wholepkg/zz_generated.expected
+++ b/examples/defaulter-gen/output_tests/wholepkg/zz_generated.expected
@@ -28,6 +28,12 @@ import (
 // Public to allow building arbitrary schemes.
 // All generated defaulters are covering - they call all nested defaulters.
 func RegisterDefaults(scheme *runtime.Scheme) error {
+	scheme.AddTypeDefaultingFunc(&Recursive_Struct_A_With_Manual_Defaulter{}, func(obj interface{}) {
+		SetObjectDefaults_Recursive_Struct_A_With_Manual_Defaulter(obj.(*Recursive_Struct_A_With_Manual_Defaulter))
+	})
+	scheme.AddTypeDefaultingFunc(&Recursive_Struct_B_With_Manual_Defaulter{}, func(obj interface{}) {
+		SetObjectDefaults_Recursive_Struct_B_With_Manual_Defaulter(obj.(*Recursive_Struct_B_With_Manual_Defaulter))
+	})
 	scheme.AddTypeDefaultingFunc(&Struct_With_Field_Has_Manual_Defaulter{}, func(obj interface{}) {
 		SetObjectDefaults_Struct_With_Field_Has_Manual_Defaulter(obj.(*Struct_With_Field_Has_Manual_Defaulter))
 	})
@@ -35,6 +41,21 @@ func RegisterDefaults(scheme *runtime.Scheme) error {
 		SetObjectDefaults_Struct_With_Field_With_Field_Has_Manual_Defaulter(obj.(*Struct_With_Field_With_Field_Has_Manual_Defaulter))
 	})
 	return nil
+}
+
+func SetObjectDefaults_Recursive_Struct_A_With_Manual_Defaulter(in *Recursive_Struct_A_With_Manual_Defaulter) {
+	SetDefaults_ManualDefault(&in.ManualDefault)
+	if in.structA != nil {
+		SetObjectDefaults_Recursive_Struct_A_With_Manual_Defaulter(in.structA)
+	}
+	SetObjectDefaults_Recursive_Struct_B_With_Manual_Defaulter(&in.structB)
+}
+
+func SetObjectDefaults_Recursive_Struct_B_With_Manual_Defaulter(in *Recursive_Struct_B_With_Manual_Defaulter) {
+	SetDefaults_ManualDefault(&in.ManualDefault)
+	if in.structA != nil {
+		SetObjectDefaults_Recursive_Struct_A_With_Manual_Defaulter(in.structA)
+	}
 }
 
 func SetObjectDefaults_Struct_With_Field_Has_Manual_Defaulter(in *Struct_With_Field_Has_Manual_Defaulter) {


### PR DESCRIPTION
Fix for defaulter-gen to support recursive types is here: https://github.com/kubernetes/gengo/pull/61.
This commit adds tests for it. The tests should pass once https://github.com/kubernetes/gengo/pull/61 is merged.

/cc @sttts